### PR TITLE
Fix rule require path

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 module.exports = {
   rules: {
-    'require-size-attributes': require('./require-size-attributes'),
+    'require-size-attributes': require('./rules/require-size-attributes'),
   },
   configs: {
     recommended: {


### PR DESCRIPTION
Ran across this error after adding the plugin:

```
Error: Cannot find module './require-size-attributes'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:636:15)
    at Function.Module._load (internal/modules/cjs/loader.js:562:25)
    at Module.require (internal/modules/cjs/loader.js:692:17)
    at require (internal/modules/cjs/helpers.js:25:18)
    at Object.<anonymous> (project/node_modules/@mizdra/eslint-plugin-layout-shift/lib/index.js:5:32)
```

Updating the `require` call with the correct relative path to the rule file fixes the issue.

